### PR TITLE
micronfcboard/pyusb_backend.py: Raise exception when pyUSB not present on Unix system

### DIFF
--- a/micronfcboard/interface/pyusb_backend.py
+++ b/micronfcboard/interface/pyusb_backend.py
@@ -23,7 +23,7 @@ try:
     import usb.util
 except:
     if os.name == "posix" and not os.uname()[0] == 'Darwin':
-        logging.error("PyUSB is required on a Linux Machine")
+        raise Exception("PyUSB is required on a Linux Machine")
     isAvailable = False
 else:
     isAvailable = True


### PR DESCRIPTION
The exception stops the execution of the program instead of continuing the execution with a less clear message.
